### PR TITLE
[Pods] Make AutolayoutExtensions available via CocoaPods

### DIFF
--- a/AutolayoutExtensions.podspec
+++ b/AutolayoutExtensions.podspec
@@ -1,0 +1,14 @@
+Pod::Spec.new do |s|
+  s.name = 'AutolayoutExtensions'
+  s.version = '0.1.1'
+  s.summary = 'A WIP autolayout helper.'
+  s.homepage = 'https://github.com/WeConnect/AutolayoutExtensions'
+  s.social_media_url = 'https://twitter.com/WeWork'
+  s.authors = { 'Scott Penrose' => 'scott.penrose@wework.com' }
+  s.source = { :git => 'git@github.com:WeConnect/AutolayoutExtensions.git', :tag => s.version }
+
+  s.swift_version = '3.0'
+  s.ios.deployment_target = '10.0'
+
+  s.source_files = 'AutolayoutExtensions/UIViewExtensions.swift'
+end

--- a/AutolayoutExtensions/UIViewExtensions.swift
+++ b/AutolayoutExtensions/UIViewExtensions.swift
@@ -9,6 +9,18 @@
 
 public extension UIView {
     
+    public func addConstraintsWithVisualFormatStrings(formatStrings: [String], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+        return addConstraintsWithVisualFormatStrings(formatStrings: formatStrings, options: [], metrics: [:], views: views)
+    }
+    
+    public func addConstraintsWithVisualFormatStrings(formatStrings: [String], metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+        return addConstraintsWithVisualFormatStrings(formatStrings: formatStrings, options: [], metrics: metrics, views: views)
+    }
+    
+    public func addConstraintsWithVisualFormatStrings(formatStrings: [String], options: NSLayoutFormatOptions, metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+        return addConstraintsWithVisualFormatStrings(formatStrings: formatStrings, options: options, metrics: metrics, views: views)
+    }
+    
     public func addConstraints(withVisualFormats formatStrings: [String], options: NSLayoutFormatOptions = [], metrics: [String: AnyObject] = [:], views: [String: AnyObject]) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
         

--- a/AutolayoutExtensions/UIViewExtensions.swift
+++ b/AutolayoutExtensions/UIViewExtensions.swift
@@ -15,7 +15,7 @@ public extension UIView {
     }
     
     @discardableResult
-    public func addConstraints(formatStrings: [String], metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+    public func addConstraints(formatStrings: [String], metrics: [String: Any], views: [String: AnyObject]) -> [NSLayoutConstraint] {
         return addConstraints(formatStrings: formatStrings, options: [], metrics: metrics, views: views)
     }
     
@@ -25,7 +25,7 @@ public extension UIView {
     }
     
     @discardableResult
-    public func addConstraints(formatStrings: [String], options: NSLayoutFormatOptions, metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+    public func addConstraints(formatStrings: [String], options: NSLayoutFormatOptions, metrics: [String: Any], views: [String: AnyObject]) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
         
         for formatString in formatStrings {

--- a/AutolayoutExtensions/UIViewExtensions.swift
+++ b/AutolayoutExtensions/UIViewExtensions.swift
@@ -66,6 +66,7 @@ public extension UIView {
                 bottom: anchorBottomToBottomEdgeOfView(view, constant: -bottomInset))
     }
     
+    @discardableResult
     public func anchorWidthAndHeightToSize(_ size: CGSize) -> (width: NSLayoutConstraint, height: NSLayoutConstraint) {
         return (width: anchorWidthToConstant(size.width),
                 height: anchorHeightToConstant(size.height))
@@ -253,6 +254,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorCenterToCenterOfView(_ view: UIView) -> (centerX: NSLayoutConstraint, centerY: NSLayoutConstraint) {
         return (centerX: anchorCenterXToCenterXOfView(view),
                 centerY: anchorCenterYToCenterYOfView(view))

--- a/AutolayoutExtensions/UIViewExtensions.swift
+++ b/AutolayoutExtensions/UIViewExtensions.swift
@@ -9,18 +9,22 @@
 
 public extension UIView {
     
+    @discardableResult
     public func addConstraints(formatStrings: [String], views: [String: AnyObject]) -> [NSLayoutConstraint] {
         return addConstraints(formatStrings: formatStrings, options: [], metrics: [:], views: views)
     }
     
+    @discardableResult
     public func addConstraints(formatStrings: [String], metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
         return addConstraints(formatStrings: formatStrings, options: [], metrics: metrics, views: views)
     }
     
+    @discardableResult
     public func addConstraints(formatStrings: [String], options: NSLayoutFormatOptions, views: [String: AnyObject]) -> [NSLayoutConstraint] {
         return addConstraints(formatStrings: formatStrings, options: options, metrics: [:], views: views)
     }
     
+    @discardableResult
     public func addConstraints(formatStrings: [String], options: NSLayoutFormatOptions, metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
         
@@ -40,6 +44,7 @@ public extension UIView {
     }
     
     /** Insets are applied as constants. bottom and trailing constants are applied in negative to produce an inset effect. */
+    @discardableResult
     public func anchorAllEdgesToView(_ view: UIView, topInset: CGFloat = 0, leadingInset: CGFloat = 0, bottomInset: CGFloat = 0, trailingInset: CGFloat = 0) -> (top: NSLayoutConstraint, leading: NSLayoutConstraint, bottom: NSLayoutConstraint, trailing: NSLayoutConstraint) {
         return (top: anchorTopToTopEdgeOfView(view, constant: topInset),
                 leading: anchorLeadingToLeadingEdgeOfView(view, constant: leadingInset),
@@ -48,12 +53,14 @@ public extension UIView {
     }
     
     /** Insets are applied as constants. trailing is applied in negative to produce an inset effect */
+    @discardableResult
     public func anchorLeadingAndTrailingEdgesToView(_ view: UIView, leadingInset: CGFloat = 0, trailingInset: CGFloat = 0) -> (leading: NSLayoutConstraint, trailing: NSLayoutConstraint) {
         return (leading: anchorLeadingToLeadingEdgeOfView(view, constant: leadingInset),
                 trailing: anchorTrailingToTrailingEdgeOfView(view, constant: -trailingInset))
     }
     
     /** Left and right insets are ignored. */
+    @discardableResult
     public func anchorTopAndBottomEdgesToView(_ view: UIView, topInset: CGFloat = 0, bottomInset: CGFloat = 0) -> (top: NSLayoutConstraint, bottom: NSLayoutConstraint) {
         return (top: anchorTopToTopEdgeOfView(view, constant: topInset),
                 bottom: anchorBottomToBottomEdgeOfView(view, constant: -bottomInset))
@@ -64,6 +71,7 @@ public extension UIView {
                 height: anchorHeightToConstant(size.height))
     }
     
+    @discardableResult
     public func anchorHeightToConstant(_ height: CGFloat) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .height,
@@ -76,6 +84,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorWidthToConstant(_ width: CGFloat) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .width,
@@ -88,6 +97,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorWidthToViewWidth(_ view: UIView, multiplier: CGFloat = 1, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .width,
@@ -100,6 +110,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorHeightToViewHeight(_ view: UIView, multiplier: CGFloat = 1, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .height,
@@ -112,6 +123,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorTopToTopEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .top,
@@ -124,6 +136,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorBottomToBottomEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .bottom,
@@ -136,6 +149,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorLeftToLeftEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .left,
@@ -148,6 +162,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorLeadingToLeadingEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .leading,
@@ -160,6 +175,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorLeadingToTrailingEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .leading,
@@ -172,6 +188,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorTrailingToLeadingEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .trailing,
@@ -184,6 +201,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorRightToRightEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .right,
@@ -196,6 +214,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorTrailingToTrailingEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .trailing,
@@ -208,6 +227,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorBottomToTopEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .bottom,
@@ -220,6 +240,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorTopToBottomEdgeOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .top,
@@ -237,6 +258,7 @@ public extension UIView {
                 centerY: anchorCenterYToCenterYOfView(view))
     }
     
+    @discardableResult
     public func anchorCenterYToCenterYOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .centerY,
@@ -249,6 +271,7 @@ public extension UIView {
         return constraint
     }
     
+    @discardableResult
     public func anchorCenterXToCenterXOfView(_ view: UIView, constant: CGFloat = 0) -> NSLayoutConstraint {
         let constraint = NSLayoutConstraint(item: self,
                                             attribute: .centerX,

--- a/AutolayoutExtensions/UIViewExtensions.swift
+++ b/AutolayoutExtensions/UIViewExtensions.swift
@@ -9,19 +9,19 @@
 
 public extension UIView {
     
-    public func addConstraintsWithVisualFormatStrings(formatStrings: [String], views: [String: AnyObject]) -> [NSLayoutConstraint] {
-        return addConstraintsWithVisualFormatStrings(formatStrings: formatStrings, options: [], metrics: [:], views: views)
+    public func addConstraints(formatStrings: [String], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+        return addConstraints(formatStrings: formatStrings, options: [], metrics: [:], views: views)
     }
     
-    public func addConstraintsWithVisualFormatStrings(formatStrings: [String], metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
-        return addConstraintsWithVisualFormatStrings(formatStrings: formatStrings, options: [], metrics: metrics, views: views)
+    public func addConstraints(formatStrings: [String], metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+        return addConstraints(formatStrings: formatStrings, options: [], metrics: metrics, views: views)
     }
     
-    public func addConstraintsWithVisualFormatStrings(formatStrings: [String], options: NSLayoutFormatOptions, metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
-        return addConstraintsWithVisualFormatStrings(formatStrings: formatStrings, options: options, metrics: metrics, views: views)
+    public func addConstraints(formatStrings: [String], options: NSLayoutFormatOptions, views: [String: AnyObject]) -> [NSLayoutConstraint] {
+        return addConstraints(formatStrings: formatStrings, options: options, metrics: [:], views: views)
     }
     
-    public func addConstraints(withVisualFormats formatStrings: [String], options: NSLayoutFormatOptions = [], metrics: [String: AnyObject] = [:], views: [String: AnyObject]) -> [NSLayoutConstraint] {
+    public func addConstraints(formatStrings: [String], options: NSLayoutFormatOptions, metrics: [String: AnyObject], views: [String: AnyObject]) -> [NSLayoutConstraint] {
         var constraints = [NSLayoutConstraint]()
         
         for formatString in formatStrings {


### PR DESCRIPTION
This PR adds a podspec and a tag so that this code may be consumed via CocoaPods. Merging it is not required for WeWork to pull it, but it may be nice to do regardless.